### PR TITLE
Refactor AuthService to use injected PasswordEncoder

### DIFF
--- a/src/main/java/dev/zwazel/security/AuthService.java
+++ b/src/main/java/dev/zwazel/security/AuthService.java
@@ -4,7 +4,6 @@ import dev.zwazel.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
@@ -13,7 +12,7 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class AuthService {
     private final UserRepository userRepository;
-    private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+    private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
 
     @Value("${jwt.cookie.name}")


### PR DESCRIPTION
## Summary
- inject `PasswordEncoder` into `AuthService`
- remove direct instantiation of `BCryptPasswordEncoder`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68517b07b1308321858f53ca4a8e7f2d