### PR TITLE
Fix login route to return 401 for bad credentials

### DIFF
--- a/src/main/java/dev/zwazel/security/AuthController.java
+++ b/src/main/java/dev/zwazel/security/AuthController.java
@@ -5,11 +5,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Mono;
 
 @RestController
@@ -35,6 +37,7 @@ public class AuthController {
         Long ttlSeconds = (req.ttlSeconds() == null || req.ttlSeconds() <= 0) ? DEFAULT_TTL : req.ttlSeconds();
 
         return authService.login(req.username(), req.password(), ttlSeconds)
+                .switchIfEmpty(Mono.error(new ResponseStatusException(HttpStatus.UNAUTHORIZED)))
                 .map(c -> {
                     log.info("LOGIN success for {}", req.username());
                     return ResponseEntity.ok()
@@ -58,6 +61,7 @@ public class AuthController {
                 .flatMap(user -> {
                     log.info("REGISTER success for {}", req.username());
                     return authService.login(req.username(), req.password(), ttlSeconds)
+                            .switchIfEmpty(Mono.error(new ResponseStatusException(HttpStatus.UNAUTHORIZED)))
                             .map(c -> ResponseEntity.ok()
                                     .header(HttpHeaders.SET_COOKIE, c.toString())
                                     .build());


### PR DESCRIPTION
## Summary
- handle empty login response with `switchIfEmpty` to throw `ResponseStatusException`
- include same handling after registration login

## Testing
- `mvn -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68517b08027c832191b9fbf354914a8b